### PR TITLE
update wording in Reduce tests to match MDN docs

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -64,12 +64,12 @@ describe('index.js', function () {
     const testArr = unmodifiedTestArr.slice() // arr is [1, 2, 3, 4]
     const callback = (acc, val, collection) => (acc + (val * 3))
 
-    it('returns the correct reduced value when passed an accumulator', function () {
+    it('returns the correct reduced value when passed an initial value', function () {
       const reduceWithAcc = fi.reduce(testArr, callback, 10)
       expect(reduceWithAcc).to.equal(40)
     })
 
-    it('returns the correct reduced value when not passed an accumulator', function () {
+    it('returns the correct reduced value when not passed an initial value', function () {
       const reduceSansAcc = fi.reduce(testArr, callback)
       expect(reduceSansAcc).to.equal(28)
     })


### PR DESCRIPTION
This test says that reduce should return a different value depending on whether an accumulator is passed. However, the accumulator is a required first argument of the reduce callback. The tests are actually passing in an initialValue or not and checking the difference in return value in either case. This just changes wording to match [what's on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce).